### PR TITLE
change default init to /usr/lib local install

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,12 +1,17 @@
-using Libdl
+if !Sys.iswindows()
+    try # check if giac installed
+        kill(run(pipeline(`giac`, stdin=devnull, stdout=devnull, stderr=stderr), wait=false))
+    catch # build
+        using Libdl
 
-cd(dirname(@__FILE__))
+        cd(dirname(@__FILE__))
 
-if (!ispath("lib"))
-  run(`mkdir lib`)
+        if (!ispath("lib"))
+          run(`mkdir lib`)
+        end
+
+        cd("src")
+        run(`make`)
+        run(`mv libgiac_c.$(dlext) ../lib`)
+    end
 end
-
-cd("src")
-run(`make`)
-run(`mv libgiac_c.$(dlext) ../lib`)
-

--- a/src/Giac.jl
+++ b/src/Giac.jl
@@ -58,8 +58,11 @@ const giac_pi = Ref{giac}()
 const giac_e = Ref{giac}()
 
 function __init__()
-    libgiac_c[] = dlopen(joinpath(dirname(@__FILE__), "..", "deps", "lib",
-                         string("libgiac_c.", dlext)))
+    libgiac_c[] = try
+        dlopen(joinpath("/usr","lib","libgiac.$dlext"))
+    catch
+        dlopen(joinpath(@__DIR__, "..", "deps", "lib","libgiac_c.$dlext"))
+    end
     context_ptr[] = ccall(dlsym(libgiac_c[], "giac_context_ptr"), Ptr{Nothing}, () )
     giac_undef[] = giac("undef") 
     global infinity = giac("infinity")


### PR DESCRIPTION
Greetings, I am on arch linux, trying to use the [libgiac](https://www.archlinux.org/packages/community/x86_64/libgiac/) package provided by the arch package manger.

I have changed the default build script to check for the presence of the `giac` program and tried to use the arch linux `libgiac` file from `/usr/lib/libgiac.so` for the initialization:
```Julia
ERROR: InitError: could not load symbol "giac_context_ptr":
/usr/lib/libgiac.so: undefined symbol: giac_context_ptr
Stacktrace:
 [1] #dlsym#1(::Bool, ::typeof(Libdl.dlsym), ::Ptr{Nothing}, ::String) at /build/julia/src/julia-1.2.0/usr/share/julia/stdlib/v1.2/Libdl/src/Libdl.jl:56
 [2] dlsym at /build/julia/src/julia-1.2.0/usr/share/julia/stdlib/v1.2/Libdl/src/Libdl.jl:54 [inlined]
 [3] __init__() at /home/flow/.julia/dev/Giac/src/Giac.jl:68
during initialization of module Giac
```
However, this does not seem to work, as `giac_context_ptr` is undefined.

Therefore, this is not a finished PR, but I think it would be a good idea to generalize the build.